### PR TITLE
Rework NoWork class

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -22,6 +22,8 @@ class Document extends Container {
       typeof opts.parser === 'undefined' &&
       typeof opts.stringifier === 'undefined' &&
       typeof opts.syntax === 'undefined' &&
+      // @TODO what to do with this warning option? do we need it here and in processor.js?
+      // Seems like we will not have a warning after NoWork is properly implemented.
       !opts.hideNothingWarning
     ) {
       result = new NoWork(new Processor(), this, opts)

--- a/lib/no-work.js
+++ b/lib/no-work.js
@@ -9,92 +9,7 @@ let warnOnce = require('./warn-once')
 let Result = require('./result')
 let parse = require('./parse')
 let Root = require('./root')
-
-const TYPE_TO_CLASS_NAME = {
-  document: 'Document',
-  root: 'Root',
-  atrule: 'AtRule',
-  rule: 'Rule',
-  decl: 'Declaration',
-  comment: 'Comment'
-}
-
-const PLUGIN_PROPS = {
-  postcssPlugin: false,
-  prepare: true,
-  Once: true,
-  Document: true,
-  Root: true,
-  Declaration: true,
-  Rule: true,
-  AtRule: true,
-  Comment: true,
-  DeclarationExit: true,
-  RuleExit: true,
-  AtRuleExit: true,
-  CommentExit: true,
-  RootExit: true,
-  DocumentExit: true,
-  OnceExit: true
-}
-
-const NOT_VISITORS = {
-  postcssPlugin: false,
-  prepare: true,
-  Once: true
-}
-
-const CHILDREN = 0
-
-function isPromise(obj) {
-  return typeof obj === 'object' && typeof obj.then === 'function'
-}
-
-function getEvents(node) {
-  let key = false
-  let type = TYPE_TO_CLASS_NAME[node.type]
-  if (node.type === 'decl') {
-    key = node.prop.toLowerCase()
-  } else if (node.type === 'atrule') {
-    key = node.name.toLowerCase()
-  }
-
-  if (key && node.append) {
-    return [
-      type,
-      type + '-' + key,
-      CHILDREN,
-      type + 'Exit',
-      type + 'Exit-' + key
-    ]
-  } else if (key) {
-    return [type, type + '-' + key, type + 'Exit', type + 'Exit-' + key]
-  } else if (node.append) {
-    return [type, CHILDREN, type + 'Exit']
-  } else {
-    return [type, type + 'Exit']
-  }
-}
-
-function toStack(node) {
-  let events
-  if (node.type === 'document') {
-    events = ['Document', CHILDREN, 'DocumentExit']
-  } else if (node.type === 'root') {
-    events = ['Root', CHILDREN, 'RootExit']
-  } else {
-    events = getEvents(node)
-  }
-
-  return {
-    node,
-    events,
-    eventIndex: 0,
-    visitors: [],
-    visitorIndex: 0,
-    iterator: 0
-  }
-}
+let LazyResult = require('./lazy-result')
 
 function cleanMarks(node) {
   node[isClean] = false
@@ -102,53 +17,19 @@ function cleanMarks(node) {
   return node
 }
 
+// @FIXME: Not sure why eslint is complaining about this. Temporary disable.
+// eslint-disable-next-line
 let postcss = {}
 
+// @TODO: Add more tests (we need 100% coverage for this class)
 class NoWork {
   constructor(processor, css, opts) {
     this.stringified = false
     this.processed = false
-
-    let root
-    if (
-      typeof css === 'object' &&
-      css !== null &&
-      (css.type === 'root' || css.type === 'document')
-    ) {
-      root = cleanMarks(css)
-    } else if (css instanceof Result) {
-      root = cleanMarks(css.root)
-      if (css.map) {
-        if (typeof opts.map === 'undefined') opts.map = {}
-        if (!opts.map.inline) opts.map.inline = false
-        opts.map.prev = css.map
-      }
-    } else {
-      let parser = parse
-      if (parser.parse) parser = parser.parse
-
-      try {
-        root = parser(css, opts)
-      } catch (error) {
-        this.processed = true
-        this.error = error
-      }
-
-      if (root && !root[my]) {
-        // istanbul ignore next
-        Container.rebuild(root)
-      }
-    }
-
-    this.result = new Result(processor, root, opts)
-    this.helpers = { ...postcss, result: this.result, postcss }
-    this.plugins = this.processor.plugins.map(plugin => {
-      if (typeof plugin === 'object' && plugin.prepare) {
-        return { ...plugin, ...plugin.prepare(this.result) }
-      } else {
-        return plugin
-      }
-    })
+    this._processor = processor
+    this._css = css
+    this._opts = opts
+    this.result = undefined
   }
 
   get [Symbol.toStringTag]() {
@@ -156,15 +37,15 @@ class NoWork {
   }
 
   get processor() {
-    return this.result.processor
+    return this._processor
   }
 
   get opts() {
-    return this.result.opts
+    return this._opts
   }
 
   get css() {
-    return this.stringify().css
+    return this._css
   }
 
   get content() {
@@ -183,17 +64,55 @@ class NoWork {
     return this.sync().messages
   }
 
+  prepareResult(processor, css, opts) {
+    let root
+    if (
+      typeof css === 'object' &&
+      css !== null &&
+      (css.type === 'root' || css.type === 'document')
+    ) {
+      root = cleanMarks(css)
+    } else if (css instanceof LazyResult || css instanceof Result) {
+      root = cleanMarks(css.root)
+      if (css.map) {
+        if (typeof opts.map === 'undefined') opts.map = {}
+        if (!opts.map.inline) opts.map.inline = false
+        opts.map.prev = css.map
+      }
+    } else {
+      let parser = parse
+      if (opts.syntax) parser = opts.syntax.parse
+      if (opts.parser) parser = opts.parser
+      if (parser.parse) parser = parser.parse
+
+      try {
+        root = parser(css, opts)
+      } catch (error) {
+        this.processed = true
+        this.error = error
+      }
+
+      if (root && !root[my]) {
+        // istanbul ignore next
+        Container.rebuild(root)
+      }
+    }
+
+    this.result = new Result(processor, root, opts)
+    return this.result
+  }
+
   warnings() {
     return this.sync().warnings()
   }
 
   toString() {
-    return this.css
+    return this._css
   }
 
   then(onFulfilled, onRejected) {
     if (process.env.NODE_ENV !== 'production') {
-      if (!('from' in this.opts)) {
+      if (!('from' in this._opts)) {
         warnOnce(
           'Without `from` option PostCSS could generate wrong source map ' +
             'and will not find Browserslist config. Set it to CSS file path ' +
@@ -201,6 +120,7 @@ class NoWork {
         )
       }
     }
+
     return this.async().then(onFulfilled, onRejected)
   }
 
@@ -215,10 +135,10 @@ class NoWork {
   async() {
     if (this.error) return Promise.reject(this.error)
     if (this.processed) return Promise.resolve(this.result)
-    if (!this.processing) {
-      this.processing = this.runAsync()
+    if (!this.result) {
+      this.prepareResult(this._processor, this._css, this._opts)
     }
-    return this.processing
+    return Promise.resolve(this.stringify())
   }
 
   sync() {
@@ -230,34 +150,14 @@ class NoWork {
       throw this.getAsyncError()
     }
 
-    for (let plugin of this.plugins) {
-      let promise = this.runOnRoot(plugin)
-      if (isPromise(promise)) {
-        throw this.getAsyncError()
-      }
-    }
-
-    this.prepareVisitors()
-    if (this.hasListener) {
-      let root = this.result.root
-      while (!root[isClean]) {
-        root[isClean] = true
-        this.walkSync(root)
-      }
-      if (this.listeners.OnceExit) {
-        if (root.type === 'document') {
-          for (let subRoot of root.nodes) {
-            this.visitSync(this.listeners.OnceExit, subRoot)
-          }
-        } else {
-          this.visitSync(this.listeners.OnceExit, root)
-        }
-      }
+    if (!this.result) {
+      this.prepareResult(this._processor, this._css, this._opts)
     }
 
     return this.result
   }
 
+  // @TODO: what to do with maps?
   stringify() {
     if (this.error) throw this.error
     if (this.stringified) return this.result
@@ -265,7 +165,10 @@ class NoWork {
 
     this.sync()
 
+    let opts = this.result.opts
     let str = stringify
+    if (opts.syntax) str = opts.syntax.stringify
+    if (opts.stringifier) str = opts.stringifier
     if (str.stringify) str = str.stringify
 
     let map = new MapGenerator(str, this.result.root, this.result.opts)
@@ -276,261 +179,8 @@ class NoWork {
     return this.result
   }
 
-  walkSync(node) {
-    node[isClean] = true
-    let events = getEvents(node)
-    for (let event of events) {
-      if (event === CHILDREN) {
-        if (node.nodes) {
-          node.each(child => {
-            if (!child[isClean]) this.walkSync(child)
-          })
-        }
-      } else {
-        let visitors = this.listeners[event]
-        if (visitors) {
-          if (this.visitSync(visitors, node.toProxy())) return
-        }
-      }
-    }
-  }
-
-  visitSync(visitors, node) {
-    for (let [plugin, visitor] of visitors) {
-      this.result.lastPlugin = plugin
-      let promise
-      try {
-        promise = visitor(node, this.helpers)
-      } catch (e) {
-        throw this.handleError(e, node.proxyOf)
-      }
-      if (node.type !== 'root' && node.type !== 'document' && !node.parent) {
-        return true
-      }
-      if (isPromise(promise)) {
-        throw this.getAsyncError()
-      }
-    }
-  }
-
-  runOnRoot(plugin) {
-    this.result.lastPlugin = plugin
-    try {
-      if (typeof plugin === 'object' && plugin.Once) {
-        if (this.result.root.type === 'document') {
-          let roots = this.result.root.nodes.map(root =>
-            plugin.Once(root, this.helpers)
-          )
-
-          if (isPromise(roots[0])) {
-            return Promise.all(roots)
-          }
-
-          return roots
-        }
-
-        return plugin.Once(this.result.root, this.helpers)
-      } else if (typeof plugin === 'function') {
-        return plugin(this.result.root, this.result)
-      }
-    } catch (error) {
-      throw this.handleError(error)
-    }
-  }
-
   getAsyncError() {
     throw new Error('Use process(css).then(cb) to work with async plugins')
-  }
-
-  handleError(error, node) {
-    let plugin = this.result.lastPlugin
-    try {
-      if (node) node.addToError(error)
-      this.error = error
-      if (error.name === 'CssSyntaxError' && !error.plugin) {
-        error.plugin = plugin.postcssPlugin
-        error.setMessage()
-      } else if (plugin.postcssVersion) {
-        if (process.env.NODE_ENV !== 'production') {
-          let pluginName = plugin.postcssPlugin
-          let pluginVer = plugin.postcssVersion
-          let runtimeVer = this.result.processor.version
-          let a = pluginVer.split('.')
-          let b = runtimeVer.split('.')
-
-          if (a[0] !== b[0] || parseInt(a[1]) > parseInt(b[1])) {
-            // eslint-disable-next-line no-console
-            console.error(
-              'Unknown error from PostCSS plugin. Your current PostCSS ' +
-                'version is ' +
-                runtimeVer +
-                ', but ' +
-                pluginName +
-                ' uses ' +
-                pluginVer +
-                '. Perhaps this is the source of the error below.'
-            )
-          }
-        }
-      }
-    } catch (err) {
-      // istanbul ignore next
-      // eslint-disable-next-line no-console
-      if (console && console.error) console.error(err)
-    }
-    return error
-  }
-
-  async runAsync() {
-    this.plugin = 0
-    for (let i = 0; i < this.plugins.length; i++) {
-      let plugin = this.plugins[i]
-      let promise = this.runOnRoot(plugin)
-      if (isPromise(promise)) {
-        try {
-          await promise
-        } catch (error) {
-          throw this.handleError(error)
-        }
-      }
-    }
-
-    this.prepareVisitors()
-    if (this.hasListener) {
-      let root = this.result.root
-      while (!root[isClean]) {
-        root[isClean] = true
-        let stack = [toStack(root)]
-        while (stack.length > 0) {
-          let promise = this.visitTick(stack)
-          if (isPromise(promise)) {
-            try {
-              await promise
-            } catch (e) {
-              let node = stack[stack.length - 1].node
-              throw this.handleError(e, node)
-            }
-          }
-        }
-      }
-
-      if (this.listeners.OnceExit) {
-        for (let [plugin, visitor] of this.listeners.OnceExit) {
-          this.result.lastPlugin = plugin
-          try {
-            if (root.type === 'document') {
-              let roots = root.nodes.map(subRoot =>
-                visitor(subRoot, this.helpers)
-              )
-
-              await Promise.all(roots)
-            } else {
-              await visitor(root, this.helpers)
-            }
-          } catch (e) {
-            throw this.handleError(e)
-          }
-        }
-      }
-    }
-
-    this.processed = true
-    return this.stringify()
-  }
-
-  prepareVisitors() {
-    this.listeners = {}
-    let add = (plugin, type, cb) => {
-      if (!this.listeners[type]) this.listeners[type] = []
-      this.listeners[type].push([plugin, cb])
-    }
-    for (let plugin of this.plugins) {
-      if (typeof plugin === 'object') {
-        for (let event in plugin) {
-          if (!PLUGIN_PROPS[event] && /^[A-Z]/.test(event)) {
-            throw new Error(
-              `Unknown event ${event} in ${plugin.postcssPlugin}. ` +
-                `Try to update PostCSS (${this.processor.version} now).`
-            )
-          }
-          if (!NOT_VISITORS[event]) {
-            if (typeof plugin[event] === 'object') {
-              for (let filter in plugin[event]) {
-                if (filter === '*') {
-                  add(plugin, event, plugin[event][filter])
-                } else {
-                  add(
-                    plugin,
-                    event + '-' + filter.toLowerCase(),
-                    plugin[event][filter]
-                  )
-                }
-              }
-            } else if (typeof plugin[event] === 'function') {
-              add(plugin, event, plugin[event])
-            }
-          }
-        }
-      }
-    }
-    this.hasListener = Object.keys(this.listeners).length > 0
-  }
-
-  visitTick(stack) {
-    let visit = stack[stack.length - 1]
-    let { node, visitors } = visit
-
-    if (node.type !== 'root' && node.type !== 'document' && !node.parent) {
-      stack.pop()
-      return
-    }
-
-    if (visitors.length > 0 && visit.visitorIndex < visitors.length) {
-      let [plugin, visitor] = visitors[visit.visitorIndex]
-      visit.visitorIndex += 1
-      if (visit.visitorIndex === visitors.length) {
-        visit.visitors = []
-        visit.visitorIndex = 0
-      }
-      this.result.lastPlugin = plugin
-      try {
-        return visitor(node.toProxy(), this.helpers)
-      } catch (e) {
-        throw this.handleError(e, node)
-      }
-    }
-
-    if (visit.iterator !== 0) {
-      let iterator = visit.iterator
-      let child
-      while ((child = node.nodes[node.indexes[iterator]])) {
-        node.indexes[iterator] += 1
-        if (!child[isClean]) {
-          child[isClean] = true
-          stack.push(toStack(child))
-          return
-        }
-      }
-      visit.iterator = 0
-      delete node.indexes[iterator]
-    }
-
-    let events = visit.events
-    while (visit.eventIndex < events.length) {
-      let event = events[visit.eventIndex]
-      visit.eventIndex += 1
-      if (event === CHILDREN) {
-        if (node.nodes && node.nodes.length) {
-          node[isClean] = true
-          visit.iterator = node.getIterator()
-        }
-        return
-      } else if (this.listeners[event]) {
-        visit.visitors = this.listeners[event]
-        return
-      }
-    }
-    stack.pop()
   }
 }
 

--- a/lib/no-work.js
+++ b/lib/no-work.js
@@ -61,7 +61,7 @@ class NoWork {
   }
 
   get messages() {
-    return this.sync().messages
+    return []
   }
 
   prepareResult(processor, css, opts) {

--- a/lib/no-work.js
+++ b/lib/no-work.js
@@ -49,7 +49,7 @@ class NoWork {
   }
 
   get content() {
-    return this.stringify().content
+    return this._css
   }
 
   get map() {

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -1,5 +1,7 @@
-import { Result, parse } from '../lib/postcss.js'
+import { Result, Stringifier, parse } from '../lib/postcss.js'
 import Document from '../lib/document.js'
+import NoWork from '../lib/no-work.js'
+import LazyResult from '../lib/lazy-result.js'
 
 it('generates result without map', () => {
   let root = parse('a {}')
@@ -23,4 +25,34 @@ it('generates result with map', () => {
 
   expect(result instanceof Result).toBe(true)
   expect(result.css).toMatch(/a {}\n\/\*# sourceMappingURL=/)
+})
+
+it('uses NoWork inside if no plugins, stringifier or parsers defined', () => {
+  let spy = jest.spyOn(NoWork.prototype, 'sync')
+  let root = parse('a {}')
+  let document = new Document()
+
+  document.append(root)
+
+  document.toResult({})
+
+  spy.mockRestore()
+})
+
+it('uses LazyWorkResult inside if stringifier defined', () => {
+  let spy = jest.spyOn(LazyResult.prototype, 'sync')
+  let root = parse('a {}')
+  let document = new Document()
+
+  document.append(root)
+
+  let customStringifier: Stringifier = doc => {
+    doc.toString()
+  }
+
+  document.toResult({ stringifier: customStringifier })
+
+  // eslint-disable-next-line
+  expect(spy).toHaveBeenCalledWith()
+  spy.mockRestore()
 })

--- a/test/no-work.test.ts
+++ b/test/no-work.test.ts
@@ -5,7 +5,13 @@ import Processor from '../lib/processor.js'
 
 let processor = new Processor()
 
-it('contains AST', () => {
+it('does not contain result if not processed', () => {
+  let noWork = new NoWork(processor, 'a {}', {})
+  // @ts-ignore
+  expect(noWork.result).toBeUndefined()
+})
+
+it('contains AST if root is accessed', () => {
   let result = new NoWork(processor, 'a {}', {})
   expect(result.root.type).toBe('root')
 })

--- a/test/root.test.ts
+++ b/test/root.test.ts
@@ -1,4 +1,6 @@
-import { Result, parse } from '../lib/postcss.js'
+import LazyResult from '../lib/lazy-result.js'
+import NoWork from '../lib/no-work.js'
+import { Result, parse, Stringifier } from '../lib/postcss.js'
 
 it('prepend() fixes spaces on insert before first', () => {
   let css = parse('a {} b {}')
@@ -59,4 +61,30 @@ it('generates result with map', () => {
 
   expect(result instanceof Result).toBe(true)
   expect(result.css).toMatch(/a {}\n\/\*# sourceMappingURL=/)
+})
+
+it('uses NoWork inside if no plugins, stringifier or parsers defined', () => {
+  let spy = jest.spyOn(NoWork.prototype, 'sync')
+  let root = parse('a {}')
+
+  root.toResult({})
+
+  // eslint-disable-next-line
+  expect(spy).toHaveBeenCalled()
+  spy.mockRestore()
+})
+
+it('uses LazyWorkResult inside if stringifier defined', () => {
+  let spy = jest.spyOn(LazyResult.prototype, 'sync')
+  let root = parse('a {}')
+
+  let customStringifier: Stringifier = doc => {
+    doc.toString()
+  }
+
+  root.toResult({ stringifier: customStringifier })
+
+  // eslint-disable-next-line
+  expect(spy).toHaveBeenCalled()
+  spy.mockRestore()
 })


### PR DESCRIPTION
Hi! This is a rework for `NoWork` class and some more tests. Here's the brief summary of what's been done:

1. Removed most of the functionality from `NoWork`. I also moved parts of code from `constructor` to  `prepareResult` function. This function parses CSS and creates `result` instance. This function runs only when `async()` or `sync()` is called, it doesn't parse css when constructor is initialized (for example, `LazyResult` parses css right after constructor call: `new LazyResult(new Processor, css, opts)`). 
2. Added tests for `document` and `root`, because otherwise coverage tools gets mad for not covering parts of the code.

We still need more tests for `NoWork` class to get 100% coverage, so this is not a final version for sure! :)

I also don't know how should we handle `async` and `sync` versions of `process` function. Right now when `process` or `stringify` is called we parse CSS. Maybe we shouldn't? I'll ask Andrey about this.

Please let me know what you think. Maybe something need to be changed?

Thank you!